### PR TITLE
Choose module path by application name

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,11 +1,11 @@
 const shared = require('./utils/shared');
 
-const preload = (content, resourcePath) => {
+const preload = (content, resourcePath, skyPagesConfig) => {
   if (!resourcePath.match(/app-extras\.module\.ts$/)) {
     return content;
   }
 
-  const modulePath = shared.getModulePath(resourcePath);
+  const modulePath = shared.getModulePath(resourcePath, skyPagesConfig);
   const provider = `STACHE_CONFIG_PROVIDERS`;
 
   content = `

--- a/src/config.spec.js
+++ b/src/config.spec.js
@@ -6,8 +6,9 @@ describe('Config Plugin', () => {
   });
 
   it('should add providers to the app-extras.module.ts file', () => {
+    const config = { skyux: { name: 'stache2'}};
     const content = new Buffer('');
-    const result = plugin.preload(content, 'app-extras.module.ts');
+    const result = plugin.preload(content, 'app-extras.module.ts', config);
     expect(result.toString()).toContain('STACHE_CONFIG_PROVIDERS');
   });
 

--- a/src/http.js
+++ b/src/http.js
@@ -5,7 +5,7 @@ const preload = (content, resourcePath, skyPagesConfig) => {
     return content;
   }
 
-  const modulePath = shared.getModulePath(resourcePath);
+  const modulePath = shared.getModulePath(resourcePath, skyPagesConfig);
   const provider = `STACHE_HTTP_PROVIDERS`;
   let httpName;
   let httpPath;

--- a/src/json-data.js
+++ b/src/json-data.js
@@ -1,13 +1,13 @@
 const jsonDataUtil = require('./utils/json-data');
 const shared = require('./utils/shared');
 
-const preload = (content, resourcePath) => {
+const preload = (content, resourcePath, skyPagesConfig) => {
   if (resourcePath.match(/\.html$/)) {
     return addElvisOperator(content);
   }
 
   if (resourcePath.match(/app-extras\.module\.ts$/)) {
-    return addGlobalDataToAppExtrasModule(content, resourcePath);
+    return addGlobalDataToAppExtrasModule(content, resourcePath, skyPagesConfig);
   }
 
   return content;
@@ -17,9 +17,9 @@ const addElvisOperator = (content) => {
   return content.toString().replace(/\{\{\s*stache.jsonData./g, '{{ stache.jsonData?.');
 };
 
-const addGlobalDataToAppExtrasModule = (content, resourcePath) => {
+const addGlobalDataToAppExtrasModule = (content, resourcePath, skyPagesConfig) => {
   const globalData = jsonDataUtil.getGlobalData();
-  const modulePath = shared.getModulePath(resourcePath);
+  const modulePath = shared.getModulePath(resourcePath, skyPagesConfig);
 
   content = `
 import {

--- a/src/json-data.spec.js
+++ b/src/json-data.spec.js
@@ -16,7 +16,8 @@ describe('JSON Data Plugin', () => {
 
   it('should add providers to the app-extras.module.ts file', () => {
     const content = new Buffer('');
-    const result = plugin.preload(content, 'app-extras.module.ts');
+    const config = { skyux: { name: 'stache2'}};
+    const result = plugin.preload(content, 'app-extras.module.ts', config);
     expect(result.toString()).toContain('STACHE_JSON_DATA_PROVIDERS');
   });
 

--- a/src/route-metadata.js
+++ b/src/route-metadata.js
@@ -72,7 +72,7 @@ const preload = (content, resourcePath, skyPagesConfig) => {
     return content;
   }
 
-  const modulePath = shared.getModulePath(resourcePath);
+  const modulePath = shared.getModulePath(resourcePath, skyPagesConfig);
 
   content = `
 import {

--- a/src/route-metadata.spec.js
+++ b/src/route-metadata.spec.js
@@ -10,6 +10,7 @@ describe('Route Metadata Plugin', () => {
   beforeEach(() => {
     plugin = require('./route-metadata');
     config = {
+      skyux: { name: 'stache2'},
       runtime: {
         routes: [
           { routePath: 'learn' },

--- a/src/utils/shared.js
+++ b/src/utils/shared.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const providersRegExp = new RegExp(/providers\s*:\s*?\[/);
+const stache2 = 'stache2';
 
 function StachePluginError(message) {
   this.name = 'StachePluginError';
@@ -40,11 +41,9 @@ const cheerioConfig = {
   decodeEntities: false
 };
 
-const getModulePath = (resourcePath) => {
-  let modulePath = '@blackbaud/stache';
-  // For backslashes, we need to convert the string to raw:
-  // https://stackoverflow.com/questions/10041998/get-backslashes-inside-a-string-javascript
-  if (String.raw`${resourcePath}`.match(/(\/|\\)stache2(\/|\\)/)) {
+const getModulePath = (resourcePath, skyPagesConfig) => {
+  let modulePath = '@blackbaud/stache'
+  if (skyPagesConfig.skyux.name === stache2) {
     modulePath = './public';
   }
 

--- a/src/utils/shared.js
+++ b/src/utils/shared.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const providersRegExp = new RegExp(/providers\s*:\s*?\[/);
-const stache2 = 'stache2';
 
 function StachePluginError(message) {
   this.name = 'StachePluginError';
@@ -43,7 +42,7 @@ const cheerioConfig = {
 
 const getModulePath = (resourcePath, skyPagesConfig) => {
   let modulePath = '@blackbaud/stache'
-  if (skyPagesConfig.skyux.name === stache2) {
+  if (skyPagesConfig.skyux.name === 'stache2') {
     modulePath = './public';
   }
 

--- a/src/utils/shared.spec.js
+++ b/src/utils/shared.spec.js
@@ -120,14 +120,16 @@ describe('Shared methods and properties', () => {
   });
 
   it('should return a resolved module path depending on its location', () => {
-    let result = shared.getModulePath('/my-spa/src/app/index.html');
+    let config = { skyux: { name: 'not-stache' }};
+    let result = shared.getModulePath('/src/app/index.html', config);
     expect(result).toBe('@blackbaud/stache');
 
-    result = shared.getModulePath('/stache2/src/app/index.html');
+    config = { skyux: { name: 'stache2' }};
+    result = shared.getModulePath('/src/app/index.html', config);
     expect(result).toBe('./public');
 
     // Windows:
-    result = shared.getModulePath(String.raw`\stache2\src\app\index.html`);
+    result = shared.getModulePath(String.raw`\stache2\src\app\index.html`, config);
     expect(result).toBe('./public');
   });
 


### PR DESCRIPTION
Application now checks for app name in properties when deciding which module to use, instead of looking for 'stache2' in the path 