### PR TITLE
Updated the public_api location when being used in Stache Library itself.

### DIFF
--- a/src/plugins/utils/shared.js
+++ b/src/plugins/utils/shared.js
@@ -43,7 +43,7 @@ const cheerioConfig = {
 const getModulePath = (resourcePath, skyPagesConfig) => {
   let modulePath = '@blackbaud/skyux-lib-stache'
   if (skyPagesConfig.skyux.name === 'skyux-lib-stache') {
-    modulePath = './public';
+    modulePath = './public/public_api';
   }
 
   return modulePath;

--- a/src/plugins/utils/shared.spec.js
+++ b/src/plugins/utils/shared.spec.js
@@ -126,11 +126,11 @@ describe('Shared methods and properties', () => {
 
     config = { skyux: { name: 'skyux-lib-stache' }};
     result = shared.getModulePath('/src/app/index.html', config);
-    expect(result).toBe('./public');
+    expect(result).toBe('./public/public_api');
 
     // Windows:
     result = shared.getModulePath(String.raw`\stache2\src\app\index.html`, config);
-    expect(result).toBe('./public');
+    expect(result).toBe('./public/public_api');
   });
 
   it('should resolve a directory for Stache assets folder', () => {


### PR DESCRIPTION
The SPA inside the `skyux-lib-stache` repo is currently unable to be served.

I'm working on fixing a bug in the Stache library and then stumbled upon this.